### PR TITLE
Meshtastic::MQTT module - overwrite payload[:macaddr] to avoid malfor…

### DIFF
--- a/lib/meshtastic/mqtt.rb
+++ b/lib/meshtastic/mqtt.rb
@@ -145,7 +145,7 @@ module Meshtastic
         mac_raw = payload[:macaddr]
         mac_hex_arr = mac_raw.bytes.map { |byte| byte.to_s(16).rjust(2, '0') }
         mac_hex_str = mac_hex_arr.join(':')
-        payload[:macaddr_hex] = mac_hex_str
+        payload[:macaddr] = mac_hex_str
       end
 
       if payload.keys.include?(:time)

--- a/lib/meshtastic/version.rb
+++ b/lib/meshtastic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Meshtastic
-  VERSION = '0.0.44'
+  VERSION = '0.0.45'
 end


### PR DESCRIPTION
…med utf-8 sequences when casting to JSON