### PR TITLE
Meshtastic.send_text method - force ASCII-8BIT when packing a payload…

### DIFF
--- a/lib/meshtastic.rb
+++ b/lib/meshtastic.rb
@@ -96,7 +96,7 @@ module Meshtastic
     port_num = Meshtastic::PortNum::TEXT_MESSAGE_APP
 
     data = Meshtastic::Data.new
-    data.payload = text
+    data.payload = text.force_encoding('ASCII-8BIT')
     data.portnum = port_num
     data.want_response = want_response
     # puts data.to_h

--- a/lib/meshtastic/version.rb
+++ b/lib/meshtastic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Meshtastic
-  VERSION = '0.0.64'
+  VERSION = '0.0.65'
 end


### PR DESCRIPTION
… into Meshtastic::PortNum::TEXT_MESSAGE_APP protobuf