### PR TITLE
Meshtastic::MQTT module - pad beginnig of text in send_text method wi…

### DIFF
--- a/lib/meshtastic/mqtt.rb
+++ b/lib/meshtastic/mqtt.rb
@@ -279,7 +279,7 @@ module Meshtastic
 
       # TODO: Implement chunked message to deal with large messages
       text = opts[:text].to_s
-      max_bytes = 232
+      max_bytes = 231
       mui = Meshtastic::MeshInterface.new
 
       if text.bytesize > max_bytes

--- a/lib/meshtastic/version.rb
+++ b/lib/meshtastic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Meshtastic
-  VERSION = '0.0.137'
+  VERSION = '0.0.138'
 end


### PR DESCRIPTION
…th a space to avoid strangeness in protocol when beginning byte is h or H proceeded by a single byte which results in {} or {bitfield: INT} #bufix_for_msgs_exceeding_max_bytes