### PR TITLE
Meshtastic::MQTT module - pad beginnig of text in send_text method wi…

### DIFF
--- a/lib/meshtastic/mqtt.rb
+++ b/lib/meshtastic/mqtt.rb
@@ -286,7 +286,7 @@ module Meshtastic
         total_chunks = (text.bytesize.to_f / max_bytes).ceil
         total_chunks.times do |i|
           chunk_num = i + 1
-          chunk_prefix = "(#{chunk_num} of #{total_chunks})"
+          chunk_prefix = " (#{chunk_num} of #{total_chunks})"
           chunk_prefix_len = chunk_prefix.bytesize
           start_index = i * (max_bytes - chunk_prefix_len)
           end_index = (start_index + (max_bytes - chunk_prefix_len)) - 1
@@ -294,7 +294,7 @@ module Meshtastic
           # This addresses a weird bug in the protocal if the first byte
           # is an h or H followed by a single byte, which returns
           # {} or {bitfiled: INT}
-          opts[:text] = " #{chunk}"
+          opts[:text] = chunk
           protobuf_chunk = mui.send_text(opts)
           mqtt_obj.publish(absolute_topic, protobuf_chunk)
         end

--- a/lib/meshtastic/version.rb
+++ b/lib/meshtastic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Meshtastic
-  VERSION = '0.0.138'
+  VERSION = '0.0.139'
 end


### PR DESCRIPTION
…th a space to avoid strangeness in protocol when beginning byte is h or H proceeded by a single byte which results in {} or {bitfield: INT} #bufix_for_msgs_exceeding_max_bytes